### PR TITLE
add isUnbound function to NodeBinding proto

### DIFF
--- a/index.js
+++ b/index.js
@@ -976,6 +976,9 @@ function NodeBinding(template, context, node) {
 }
 NodeBinding.prototype = new Binding();
 NodeBinding.prototype.type = 'NodeBinding';
+NodeBinding.prototype.isUnbound = function() {
+  return false;
+}
 
 function AttributeBindingsMap() {}
 function AttributeBinding(template, context, element, name) {


### PR DESCRIPTION
I`m not sure what was the idea, but this function is expected here: https://github.com/codeparty/derby/blob/master/lib/documentListeners.js#L35
and here: https://github.com/codeparty/derby/blob/master/lib/documentListeners.js#L47

And it cause error for textarea binding.
