### PR TITLE
don't add comments when unbound

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,14 +372,19 @@ DynamicHtml.prototype.appendTo = function(parent, context, binding) {
   }
 };
 DynamicHtml.prototype.attachTo = function(parent, node, context) {
-  var start = document.createComment(this.expression);
-  var end = document.createComment(this.ending);
+  var bound = this.expression.meta.bindType !== 'unbound';
+  if (bound) {
+    var start = document.createComment(this.expression);
+    var end = document.createComment(this.ending);
+  }
   var value = getUnescapedValue(this.expression, context);
   var html = this.stringify(value);
-  parent.insertBefore(start, node || null);
+  if (bound) parent.insertBefore(start, node || null);
   node = attachHtml(parent, node, html);
-  parent.insertBefore(end, node || null);
-  updateRange(context, null, this, start, end);
+  if (bound) {
+    parent.insertBefore(end, node || null);
+    updateRange(context, null, this, start, end);
+  }
   return node;
 };
 DynamicHtml.prototype.update = function(context, binding) {


### PR DESCRIPTION
This is just a suggestion for a feature and the implementation may not be correct. Take it as an idea if you will.

What this does is avoid adding comments like `<!--unescaped unbound hello.message-->` when the path is unbound and unescaped.

The motivation for this is that 1) these comments are making the life hard in some cases 2) if the path is unbound, I don't think these comments need to be there?

For 1) the case is when I'm making a html editor and I'm using `unbound unescaped` to make the html snippet editable, the extra comments are something extra that I would like to avoid.
