### PR TITLE
Evaluate this.expression for Block if it's necessary 

### DIFF
--- a/example/expressions.js
+++ b/example/expressions.js
@@ -21,7 +21,8 @@ if (typeof require === 'function') {
 module.exports = {
   Expression: Expression,
   ElseExpression: ElseExpression,
-  Context: Context
+  Context: Context,
+  ContextMeta: ContextMeta
 };
 
 function Expression(source) {
@@ -94,4 +95,32 @@ Context.prototype._get = function(property) {
   return (this.data && this.data.hasOwnProperty(property)) ?
     this.data[property] :
     this.parent && this.parent._get(property);
+};
+Context.prototype.pause = function() {
+  this.meta.pauseCount++;
+};
+Context.prototype.unpause = function() {
+  if (--this.meta.pauseCount) return;
+  this.flush();
+};
+Context.prototype.flush = function() {
+  var pending = this.meta.pending;
+  var len = pending.length;
+  if (!len) return;
+  this.meta.pending = [];
+  for (var i = 0; i < len; i++) {
+    pending[i]();
+  }
+};
+Context.prototype.queue = function(cb) {
+  this.meta.pending.push(cb);
+};
+
+function noop() {}
+function ContextMeta() {
+  this.addBinding = noop;
+  this.removeBinding = noop;
+  this.removeNode = noop;
+  this.pauseCount = 0;
+  this.pending = [];
 };

--- a/index.js
+++ b/index.js
@@ -502,7 +502,7 @@ AttributesExpression.prototype.update = function(context, binding) {
   var oldValue = binding.oldValue;
   if (oldValue) {
     for (var key in oldValue) {
-      if (!(oldValue in value)) {
+      if (!(key in value)) {
         var propertyName = !this.elementNs && UPDATE_PROPERTIES[key];
         if (propertyName) {
           element[propertyName] = null;
@@ -521,11 +521,11 @@ AttributesExpression.prototype.update = function(context, binding) {
       if (propertyName === 'value' && (element.value === attrValue || element.valueAsNumber === attrValue)) return;
       if (attrValue === void 0) attrValue = null;
       element[propertyName] = attrValue;
-      return;
+      continue;
     }
     if (attrValue === false || attrValue == null) {
       element.removeAttribute(key);
-      return;
+      continue;
     }
     if (attrValue === true) attrValue = key;
     element.setAttribute(key, attrValue);

--- a/index.js
+++ b/index.js
@@ -635,8 +635,14 @@ Block.prototype.get = function(context, unescaped) {
 };
 Block.prototype.appendTo = function(parent, context, binding) {
   var blockContext = context.child(this.expression);
-  var start = document.createComment(this.expression);
-  var end = document.createComment(this.ending);
+  var begining = this.expression;
+  var ending = this.ending;
+  if (this.expression && this.expression.get) {
+    begining = this.expression.get(context);
+    ending = '/' + begining;
+  }
+  var start = document.createComment(begining);
+  var end = document.createComment(ending);
   var condition = this.getCondition(context);
   parent.appendChild(start);
   appendContent(parent, this.content, blockContext);
@@ -645,8 +651,14 @@ Block.prototype.appendTo = function(parent, context, binding) {
 };
 Block.prototype.attachTo = function(parent, node, context) {
   var blockContext = context.child(this.expression);
-  var start = document.createComment(this.expression);
-  var end = document.createComment(this.ending);
+  var begining = this.expression;
+  var ending = this.ending;
+  if (this.expression && this.expression.get) {
+    begining = this.expression.get(context);
+    ending = '/' + begining;
+  }
+  var start = document.createComment(begining);
+  var end = document.createComment(ending);
   var condition = this.getCondition(context);
   parent.insertBefore(start, node || null);
   node = attachContent(parent, node, this.content, blockContext);

--- a/index.js
+++ b/index.js
@@ -107,10 +107,15 @@ Template.prototype.getFragment = function(context, binding) {
   return fragment;
 };
 Template.prototype.appendTo = function(parent, context) {
+  context.pause();
   appendContent(parent, this.content, context);
+  context.unpause();
 };
 Template.prototype.attachTo = function(parent, node, context) {
-  return attachContent(parent, node, this.content, context);
+  context.pause();
+  var node = attachContent(parent, node, this.content, context);
+  context.unpause();
+  return node;
 };
 Template.prototype.update = function() {};
 Template.prototype.stringify = function(value) {
@@ -261,8 +266,8 @@ Comment.prototype.get = function() {
 };
 Comment.prototype.appendTo = function(parent, context) {
   var node = document.createComment(this.data);
-  emitHooks(this.hooks, context, node);
   parent.appendChild(node);
+  emitHooks(this.hooks, context, node);
 };
 Comment.prototype.attachTo = function(parent, node, context) {
   return attachComment(parent, node, this.data, this, context);
@@ -321,10 +326,10 @@ function attachComment(parent, node, data, template, context) {
 }
 
 function addNodeBinding(template, context, node) {
-  emitHooks(template.hooks, context, node);
   if (template.expression) {
     context.addBinding(new NodeBinding(template, context, node));
   }
+  emitHooks(template.hooks, context, node);
 }
 
 function Html(data) {
@@ -527,7 +532,6 @@ Element.prototype.appendTo = function(parent, context) {
   var element = (this.ns) ?
     document.createElementNS(this.ns, tagName) :
     document.createElement(tagName);
-  emitHooks(this.hooks, context, element);
   for (var key in this.attributes) {
     var attribute = this.attributes[key];
     var value = attribute.getBound(context, element, key, this.ns);
@@ -546,6 +550,7 @@ Element.prototype.appendTo = function(parent, context) {
   }
   if (this.content) appendContent(element, this.content, context);
   parent.appendChild(element);
+  emitHooks(this.hooks, context, element);
 };
 Element.prototype.attachTo = function(parent, node, context) {
   var tagName = this.getTagName(context);
@@ -556,7 +561,6 @@ Element.prototype.attachTo = function(parent, node, context) {
   ) {
     throw attachError(parent, node);
   }
-  emitHooks(this.hooks, context, node);
   for (var key in this.attributes) {
     // Get each attribute to create bindings
     this.attributes[key].getBound(context, node, key, this.ns);
@@ -564,6 +568,7 @@ Element.prototype.attachTo = function(parent, node, context) {
     // are equivalent, but there are some tricky edge cases
   }
   if (this.content) attachContent(node, node.firstChild, this.content, context);
+  emitHooks(this.hooks, context, node);
   return node.nextSibling;
 };
 Element.prototype.type = 'Element';
@@ -618,9 +623,11 @@ function getAttributeValue(element, name) {
 
 function emitHooks(hooks, context, value) {
   if (!hooks) return;
-  for (var i = 0, len = hooks.length; i < len; i++) {
-    hooks[i].emit(context, value);
-  }
+  context.queue(function queuedHooks() {
+    for (var i = 0, len = hooks.length; i < len; i++) {
+      hooks[i].emit(context, value);
+    }
+  });
 }
 
 function Block(expression, content) {
@@ -1026,7 +1033,9 @@ function Binding() {
 }
 Binding.prototype.type = 'Binding';
 Binding.prototype.update = function() {
+  this.context.pause();
   this.template.update(this.context, this);
+  this.context.unpause();
 };
 Binding.prototype.insert = function() {
   this.update();
@@ -1075,25 +1084,31 @@ function RangeBinding(template, context, start, end, itemFor, condition) {
 RangeBinding.prototype = new Binding();
 RangeBinding.prototype.type = 'RangeBinding';
 RangeBinding.prototype.insert = function(index, howMany) {
+  this.context.pause();
   if (this.template.insert) {
     this.template.insert(this.context, this, index, howMany);
   } else {
     this.template.update(this.context, this);
   }
+  this.context.unpause();
 };
 RangeBinding.prototype.remove = function(index, howMany) {
+  this.context.pause();
   if (this.template.remove) {
     this.template.remove(this.context, this, index, howMany);
   } else {
     this.template.update(this.context, this);
   }
+  this.context.unpause();
 };
 RangeBinding.prototype.move = function(from, to, howMany) {
+  this.context.pause();
   if (this.template.move) {
     this.template.move(this.context, this, from, to, howMany);
   } else {
     this.template.update(this.context, this);
   }
+  this.context.unpause();
 };
 
 

--- a/index.js
+++ b/index.js
@@ -488,8 +488,8 @@ AttributesExpression.prototype.get = function(context) {
   var value;
   if (this.expression.type === 'SequenceExpression') {
     value = {};
-    for (var i = 0, exression; exression = this.expression.args[i++];) {
-      var curValue = getUnescapedValue(exression, context);
+    for (var i = 0, expression; expression = this.expression.args[i++];) {
+      var curValue = getUnescapedValue(expression, context);
       if (curValue) {
         for (var key in curValue) {
           value[key] = curValue[key];

--- a/index.js
+++ b/index.js
@@ -481,22 +481,42 @@ DynamicAttribute.prototype.serialize = function() {
 
 function AttributesExpression(expression) {
   this.expression = expression;
+  expression.supportObject = true;
   this.elementNs = null;
 }
 AttributesExpression.prototype.get = function(context) {
-  return getUnescapedValue(this.expression, context);
+  var value;
+  if (this.expression.type === 'SequenceExpression') {
+    value = {};
+    for (var i = 0, exression; exression = this.expression.args[i++];) {
+      var curValue = getUnescapedValue(exression, context);
+      if (curValue) {
+        for (var key in curValue) {
+          value[key] = curValue[key];
+        }
+      }
+    }
+    return value;
+  }
+  value = getUnescapedValue(this.expression, context) || {};
+  if (typeof value !== 'object') {
+    var plainValue = value;
+    value = {};
+    value.attributes = plainValue;
+  }
+  return value;
 };
 AttributesExpression.prototype.getBound = function(context, element, key, elementNs) {
   this.elementNs = elementNs;
   var binding = new AttributeBinding(this, context, element, key);
   context.addBinding(binding);
-  var value = getUnescapedValue(this.expression, context);
+  var value = this.get(context);
   binding.oldValue = {};
   for (var key in value) binding.oldValue[key] = value[key];
   return value;
 };
 AttributesExpression.prototype.update = function(context, binding) {
-  var value = getUnescapedValue(this.expression, context) || {};
+  var value = this.get(context);
   var element = binding.element;
   
   var oldValue = binding.oldValue;
@@ -537,8 +557,7 @@ AttributesExpression.prototype.type = 'AttributesExpression';
 AttributesExpression.prototype.module = 'templates';
 AttributesExpression.prototype.serialize = function() {
   return serializeObject.instance(this, this.expression);
-};
-
+}; 
 
 function getUnescapedValue(expression, context) {
   var unescaped = true;
@@ -582,15 +601,13 @@ Element.prototype.get = function(context) {
       value = {};
       value[key] = singleValue;
     }
-    if (value) {
-      for (var attrKey in value) {
-        if (attrKey) {
-          var attrValue = value[attrKey];
-          if (attrValue === true) {
-            tagItems.push(attrKey);
-          } else if (attrValue !== false && attrValue != null) {
-            tagItems.push(attrKey + '="' + escapeAttribute(attrValue) + '"');
-          }
+    for (var attrKey in value) {
+      if (attrKey) {
+        var attrValue = value[attrKey];
+        if (attrValue === true) {
+          tagItems.push(attrKey);
+        } else if (attrValue !== false && attrValue != null) {
+          tagItems.push(attrKey + '="' + escapeAttribute(attrValue) + '"');
         }
       }
     }
@@ -615,22 +632,20 @@ Element.prototype.appendTo = function(parent, context) {
       value = {};
       value[key] = singleValue;
     }
-    if (value) {
-      for (var attrKey in value) {
-        if (!attrKey) continue;
-        var attrValue = value[attrKey];
-        if (attrValue === false || attrValue == null) continue;
-        var propertyName = !this.ns && CREATE_PROPERTIES[attrKey];
-        if (propertyName) {
-          element[propertyName] = attrValue;
-          continue;
-        }
-        if (attrValue === true) attrValue = attrKey;
-        if (attribute.ns) {
-          element.setAttributeNS(attribute.ns, attrKey, attrValue);
-        } else {
-          element.setAttribute(attrKey, attrValue);
-        }
+    for (var attrKey in value) {
+      if (!attrKey) continue;
+      var attrValue = value[attrKey];
+      if (attrValue === false || attrValue == null) continue;
+      var propertyName = !this.ns && CREATE_PROPERTIES[attrKey];
+      if (propertyName) {
+        element[propertyName] = attrValue;
+        continue;
+      }
+      if (attrValue === true) attrValue = attrKey;
+      if (attribute.ns) {
+        element.setAttributeNS(attribute.ns, attrKey, attrValue);
+      } else {
+        element.setAttribute(attrKey, attrValue);
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -502,7 +502,7 @@ AttributesExpression.prototype.update = function(context, binding) {
   var oldValue = binding.oldValue;
   if (oldValue) {
     for (var key in oldValue) {
-      if (!(key in value)) {
+      if (key && !(key in value)) {
         var propertyName = !this.elementNs && UPDATE_PROPERTIES[key];
         if (propertyName) {
           element[propertyName] = null;
@@ -513,6 +513,7 @@ AttributesExpression.prototype.update = function(context, binding) {
   }
   
   for (var key in value) {
+    if (!key) continue;
     var attrValue = value[key];
     var propertyName = !this.elementNs && UPDATE_PROPERTIES[key];
     if (propertyName) {
@@ -583,11 +584,13 @@ Element.prototype.get = function(context) {
     }
     if (value) {
       for (var attrKey in value) {
-        var attrValue = value[attrKey];
-        if (attrValue === true) {
-          tagItems.push(attrKey);
-        } else if (attrValue !== false && attrValue != null) {
-          tagItems.push(attrKey + '="' + escapeAttribute(attrValue) + '"');
+        if (attrKey) {
+          var attrValue = value[attrKey];
+          if (attrValue === true) {
+            tagItems.push(attrKey);
+          } else if (attrValue !== false && attrValue != null) {
+            tagItems.push(attrKey + '="' + escapeAttribute(attrValue) + '"');
+          }
         }
       }
     }
@@ -614,6 +617,7 @@ Element.prototype.appendTo = function(parent, context) {
     }
     if (value) {
       for (var attrKey in value) {
+        if (!attrKey) continue;
         var attrValue = value[attrKey];
         if (attrValue === false || attrValue == null) continue;
         var propertyName = !this.ns && CREATE_PROPERTIES[attrKey];

--- a/index.js
+++ b/index.js
@@ -507,9 +507,7 @@ AttributesExpression.prototype.update = function(context, binding) {
         if (propertyName) {
           element[propertyName] = null;
         }
-        else {
-          element.removeAttribute(key);
-        }
+        element.removeAttribute(key);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/codeparty/saddle"
   },
-  "version": "0.5.8",
+  "version": "0.6.0",
   "main": "./lib/index.js",
   "scripts": {
     "test": "mocha --recursive test --bail --colors --reporter spec --debug"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/codeparty/saddle"
   },
-  "version": "0.6.0c",
+  "version": "0.6.0d",
   "main": "./lib/index.js",
   "scripts": {
     "test": "mocha --recursive test --bail --colors --reporter spec --debug"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/codeparty/saddle"
   },
-  "version": "0.6.0a",
+  "version": "0.6.0b",
   "main": "./lib/index.js",
   "scripts": {
     "test": "mocha --recursive test --bail --colors --reporter spec --debug"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/codeparty/saddle"
   },
-  "version": "0.6.0d",
+  "version": "0.6.0e",
   "main": "./lib/index.js",
   "scripts": {
     "test": "mocha --recursive test --bail --colors --reporter spec --debug"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/codeparty/saddle"
   },
-  "version": "0.6.0",
+  "version": "0.6.0a",
   "main": "./lib/index.js",
   "scripts": {
     "test": "mocha --recursive test --bail --colors --reporter spec --debug"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/codeparty/saddle"
   },
-  "version": "0.6.0b",
+  "version": "0.6.0c",
   "main": "./lib/index.js",
   "scripts": {
     "test": "mocha --recursive test --bail --colors --reporter spec --debug"

--- a/test/test.mocha.js
+++ b/test/test.mocha.js
@@ -10,16 +10,18 @@ document.write('<div id="fixture"></div>');
 
 describe('Static rendering', function() {
 
+  var context = getContext();
+
   describe('HTML', function() {
     testStaticRendering(function test(options) {
-      var html = options.template.get();
+      var html = options.template.get(context);
       expect(html).equal(options.html);
     });
   });
 
   describe('Fragment', function() {
     testStaticRendering(function test(options) {
-      var fragment = options.template.getFragment();
+      var fragment = options.template.getFragment(context);
       options.fragment(fragment);
     });
   });
@@ -318,7 +320,8 @@ describe('attachTo', function() {
     removeChildren(fixture);
   });
 
-  function renderAndAttach(template, context) {
+  function renderAndAttach(template) {
+    var context = getContext();
     removeChildren(fixture);
     fixture.innerHTML = template.get(context);
     template.attachTo(fixture, fixture.firstChild, context);
@@ -951,12 +954,9 @@ function testBindingUpdates(render) {
 }
 
 function getContext(data, bindings) {
-  var contextMeta = {
-    addBinding: function(binding) {
-      bindings && bindings.push(binding);
-    }
-  , removeBinding: function() {}
-  , removeNode: function() {}
+  var contextMeta = new expressions.ContextMeta();
+  contextMeta.addBinding = function(binding) {
+    bindings && bindings.push(binding);
   };
   return new expressions.Context(contextMeta, data);
 }


### PR DESCRIPTION
Sometimes expression for Block is not string, but Expression which should be evaluated (e.g. for DynamicViewInstance which is wrapped by Block). Because of this, we get begin comment for Block like this: <!--[object Object]-->. It can cause attach error.
