### PR TITLE
Attributes expression support

### DIFF
--- a/index.js
+++ b/index.js
@@ -502,7 +502,7 @@ AttributesExpression.prototype.update = function(context, binding) {
   var oldValue = binding.oldValue;
   if (oldValue) {
     for (var key in oldValue) {
-      if (!(oldValue in value)) {
+      if (!(key in value)) {
         var propertyName = !this.elementNs && UPDATE_PROPERTIES[key];
         if (propertyName) {
           element[propertyName] = null;
@@ -521,11 +521,11 @@ AttributesExpression.prototype.update = function(context, binding) {
       if (propertyName === 'value' && (element.value === attrValue || element.valueAsNumber === attrValue)) return;
       if (attrValue === void 0) attrValue = null;
       element[propertyName] = attrValue;
-      return;
+      continue;
     }
     if (attrValue === false || attrValue == null) {
       element.removeAttribute(key);
-      return;
+      continue;
     }
     if (attrValue === true) attrValue = key;
     element.setAttribute(key, attrValue);

--- a/index.js
+++ b/index.js
@@ -488,8 +488,8 @@ AttributesExpression.prototype.get = function(context) {
   var value;
   if (this.expression.type === 'SequenceExpression') {
     value = {};
-    for (var i = 0, exression; exression = this.expression.args[i++];) {
-      var curValue = getUnescapedValue(exression, context);
+    for (var i = 0, expression; expression = this.expression.args[i++];) {
+      var curValue = getUnescapedValue(expression, context);
       if (curValue) {
         for (var key in curValue) {
           value[key] = curValue[key];

--- a/index.js
+++ b/index.js
@@ -502,7 +502,7 @@ AttributesExpression.prototype.update = function(context, binding) {
   var oldValue = binding.oldValue;
   if (oldValue) {
     for (var key in oldValue) {
-      if (!(key in value)) {
+      if (key && !(key in value)) {
         var propertyName = !this.elementNs && UPDATE_PROPERTIES[key];
         if (propertyName) {
           element[propertyName] = null;
@@ -513,6 +513,7 @@ AttributesExpression.prototype.update = function(context, binding) {
   }
   
   for (var key in value) {
+    if (!key) continue;
     var attrValue = value[key];
     var propertyName = !this.elementNs && UPDATE_PROPERTIES[key];
     if (propertyName) {
@@ -583,11 +584,13 @@ Element.prototype.get = function(context) {
     }
     if (value) {
       for (var attrKey in value) {
-        var attrValue = value[attrKey];
-        if (attrValue === true) {
-          tagItems.push(attrKey);
-        } else if (attrValue !== false && attrValue != null) {
-          tagItems.push(attrKey + '="' + escapeAttribute(attrValue) + '"');
+        if (attrKey) {
+          var attrValue = value[attrKey];
+          if (attrValue === true) {
+            tagItems.push(attrKey);
+          } else if (attrValue !== false && attrValue != null) {
+            tagItems.push(attrKey + '="' + escapeAttribute(attrValue) + '"');
+          }
         }
       }
     }
@@ -614,6 +617,7 @@ Element.prototype.appendTo = function(parent, context) {
     }
     if (value) {
       for (var attrKey in value) {
+        if (!attrKey) continue;
         var attrValue = value[attrKey];
         if (attrValue === false || attrValue == null) continue;
         var propertyName = !this.ns && CREATE_PROPERTIES[attrKey];

--- a/index.js
+++ b/index.js
@@ -507,9 +507,7 @@ AttributesExpression.prototype.update = function(context, binding) {
         if (propertyName) {
           element[propertyName] = null;
         }
-        else {
-          element.removeAttribute(key);
-        }
+        element.removeAttribute(key);
       }
     }
   }


### PR DESCRIPTION
Support for templates like this <div attributes="{{attrs}}"></div>, where attrs is object (keys are attributes names, values are attributes values)

I created corresponding pull-requests to derby-templates (https://github.com/derbyjs/derby-templates/pull/9) and derby-parsing (https://github.com/derbyjs/derby-parsing/pull/7).

See example here: http://jsfiddle.net/mrThomasTeller/wgyqu06b/
