### PR TITLE
Fix DynamicAttribute.update for false, null, and undefined so it removes attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 [![browser support](https://ci.testling.com/derbyjs/saddle.png)](https://ci.testling.com/derbyjs/saddle)
 
 # Saddle
+
+Saddle contains the various `Template` and `Binding` classes for [DerbyJS](https://github.com/derbyjs/derby).
+
+Saddle doesn't directly depend on any other part of Derby, but to use Saddle, you do need an implementation of `Expression` to pass to `Template`s.
+
+* There are a couple small example `Expression` implementations in [expressions.js](https://github.com/derbyjs/saddle/blob/master/example/expressions.js).
+* Derby's full implementations of `Expression`s are in [derbyjs/derby-templates](https://github.com/derbyjs/derby-templates/blob/master/lib/expressions.js).
+
+## Installation
+
+```
+npm install saddle
+```
+
+## Tests
+
+```
+npm test
+```
+
+Some of Saddle's tests require a DOM to run, so after running the in-memory tests, `npm test` will print out a URL to run browser-based tests.

--- a/index.js
+++ b/index.js
@@ -497,19 +497,19 @@ DynamicAttribute.prototype.getBound = function(context, element, name, elementNs
 DynamicAttribute.prototype.update = function(context, binding) {
   var value = getUnescapedValue(this.expression, context);
   var element = binding.element;
-  var propertyName = !this.elementNs && UPDATE_PROPERTIES[binding.name];
-  if (propertyName) {
-    if (propertyName === 'value') value = this.stringify(value);
-    if (element[propertyName] === value) return;
-    element[propertyName] = value;
-    return;
-  }
   if (value === false || value == null) {
     if (this.ns) {
       element.removeAttributeNS(this.ns, binding.name);
     } else {
       element.removeAttribute(binding.name);
     }
+    return;
+  }
+  var propertyName = !this.elementNs && UPDATE_PROPERTIES[binding.name];
+  if (propertyName) {
+    if (propertyName === 'value') value = this.stringify(value);
+    if (element[propertyName] === value) return;
+    element[propertyName] = value;
     return;
   }
   if (value === true) value = binding.name;

--- a/package.json
+++ b/package.json
@@ -9,14 +9,16 @@
   "version": "0.8.0",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha --recursive test --bail --colors --reporter spec --debug"
+    "test": "mocha test/serialize.mocha.js --bail --colors --reporter spec; node test/testServer.js"
   },
   "dependencies": {
     "serialize-object": "^1.0.0"
   },
   "devDependencies": {
+    "expect.js": "~0.2.0",
+    "finalhandler": "^1.1.1",
     "mocha": "~1.9.0",
-    "expect.js": "~0.2.0"
+    "serve-static": "^1.13.2"
   },
   "optionalDependencies": {},
   "testling": {

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -1,0 +1,36 @@
+var finalhandler = require('finalhandler');
+var http = require('http');
+var path = require('path');
+var serveStatic = require('serve-static');
+
+
+// Default port is 5555. Override it with `PORT=____`,
+// or `PORT=0` to let Node pick an unused port.
+var port = parseInt(process.env.PORT, 10);
+if (!Number.isInteger(port)) {
+  port = 5555;
+}
+// The test server only serves to this local machine by default.
+// To access it from any other network device, use `HOST=0.0.0.0`,
+// but be sure you trust the network you're on.
+var bindHost = process.env.HOST || '127.0.0.1';
+
+
+// Serve files under Saddle's base directory, since test.html
+// loads Mocha from node_modules with a relative path.
+var serveTestDir = serveStatic(path.dirname(__dirname));
+var server = http.createServer(function onRequest(req, res) {
+  serveTestDir(req, res, finalhandler(req, res));
+});
+
+server.listen(port, bindHost, function(err) {
+  if (err) {
+    console.log('Error starting browser test server:', err);
+    server.close();
+  } else {
+    var testUrl = 'http://127.0.0.1:' + port + '/test/test.html';
+    console.log('Test server started on network interface ' + bindHost + '.');
+    console.log('\nTo run browser tests, visit this URL:\n');
+    console.log('    ' + testUrl);
+  }
+});


### PR DESCRIPTION
# The issue

@jylauril and I discovered that for a `DynamicAttribute` in the [`UPDATE_PROPERTIES`](https://github.com/derbyjs/saddle/blob/c0ee398cbb8e4c47f59287e966d5ec889eab991b/index.js#L5) map like `title`, calling `update()` when its expression produces a value of false, null, or defined results in the HTML attribute getting set to a string, i.e. "false", "null", or "undefined".

This `update` behavior is inconsistent with the two types of static rendering, both of which don't write the attribute out with values of false, null, or undefined:

* In `Element.get`, which renders to HTML string, the attribute only gets appended [if `value !== false && value != null`](https://github.com/derbyjs/saddle/blob/c0ee398cbb8e4c47f59287e966d5ec889eab991b/index.js#L525-L527).
* In `Element.appendTo`, which renders a new element with DOM methods, the attribute doesn't get set [if `value === false || value == null`](https://github.com/derbyjs/saddle/blob/c0ee398cbb8e4c47f59287e966d5ec889eab991b/index.js#L544).

To reproduce this issue in Derby:

* Have a component that includes `<button title="{{myTooltip}}" on-click="model.del('myTooltip')">`.
* In the controller's `init()`, include `this.model.set('myTooltip', 'My tooltip');` so that initial rendering is a non-empty string.
* You'll end up with `<button title="undefined">`, and hovering over the button shows a tooltip that says "undefined".

# Changes in this PR

* Add tests for the `title` attribute, including cases to cover values of `undefined`. You can check out at commit 1d098b2 to see that the tests for `undefined` fail without the fix.
* The fix:
  * `DynamicAttribute.update` already does `removeAttribute` for false/null/undefined, but it happens after the special casing for `UPDATE_PROPERTIES`, which early-exits. That's why the issue only occurs for attributes in that special list.
  * I've moved the false-y check and `removeAttribute` to above the special casing, so that it happens consistently for all attributes.
* And while I was at it, some dev improvements:
  * `npm test` didn't work out of the box, since test.mocha.js requires a DOM to run. For convenience, I added a testServer.js to serve the existing test.html to a browser and changed the `npm test` command to run non-DOM tests and then start the test server.
  * I removed the `--debug` param from `npm test`, since that was removed from Node 8 in favor of `--inspect`. You can still pass `--inspect`/`--inspect-brk` yourself to debug the non-DOM tests, or use browser breakpoints to debug the DOM tests.
  * Added some content to the previously-empty README! 🎉 

# Open questions

* Should the tests cover the other attributes in `UPDATE_PROPERTIES` too, or is just covering `title` sufficient? I didn't want to loop over and generate tests for each because different ones accept different types of values.
* Should I backport this to saddle@0.5.x, given that Derby has issues with saddle@0.6.0?
* Should the DOM-based tests include and use jsdom by default so that all tests can run out of the box in the Mocha process? We'd still keep the option to run in a browser for compatibility testing.