### PR TITLE
implement support for custom equality function on condition objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -1225,8 +1225,8 @@ function escapeAttribute(string) {
 function equalConditions(a, b) {
   // First, test for strict equality
   if (a === b) return true;
-  // Failing that, allow for condition objects to define a custom `equals()`
-  // method to indicate equivalence
+  // Failing that, allow for template objects used as a condition to define a
+  // custom `equals()` method to indicate equivalence
   return (a instanceof Template) && a.equals(b);
 }
 

--- a/index.js
+++ b/index.js
@@ -137,6 +137,9 @@ Template.prototype.update = function() {};
 Template.prototype.stringify = function(value) {
   return (value == null) ? '' : value + '';
 };
+Template.prototype.equals = function(other) {
+  return this === other;
+};
 Template.prototype.module = 'templates';
 Template.prototype.type = 'Template';
 Template.prototype.serialize = function() {
@@ -1224,7 +1227,7 @@ function equalConditions(a, b) {
   if (a === b) return true;
   // Failing that, allow for condition objects to define a custom `equals()`
   // method to indicate equivalence
-  return (a && (typeof a.equals === 'function') && a.equals(b)) ? true : false;
+  return (a instanceof Template) && a.equals(b);
 }
 
 

--- a/index.js
+++ b/index.js
@@ -752,7 +752,8 @@ Block.prototype.serialize = function() {
 Block.prototype.update = function(context, binding) {
   if (!binding.start.parentNode) return;
   var condition = this.getCondition(context);
-  if (condition === binding.condition) return;
+  // Cancel update if prior condition is equivalent to current value
+  if (equalConditions(condition, binding.condition)) return;
   binding.condition = condition;
   // Get start and end in advance, since binding is mutated in getFragment
   var start = binding.start;
@@ -824,7 +825,8 @@ ConditionalBlock.prototype.serialize = function() {
 ConditionalBlock.prototype.update = function(context, binding) {
   if (!binding.start.parentNode) return;
   var condition = this.getCondition(context);
-  if (condition === binding.condition) return;
+  // Cancel update if prior condition is equivalent to current value
+  if (equalConditions(condition, binding.condition)) return;
   binding.condition = condition;
   // Get start and end in advance, since binding is mutated in getFragment
   var start = binding.start;
@@ -1215,6 +1217,14 @@ function escapeAttribute(string) {
   return string.replace(/[&"]/g, function(match) {
     return (match === '&') ? '&amp;' : '&quot;';
   });
+}
+
+function equalConditions(a, b) {
+  // First, test for strict equality
+  if (a === b) return true;
+  // Failing that, allow for condition objects to define a custom `equals()`
+  // method to indicate equivalence
+  return (a && (typeof a.equals === 'function') && a.equals(b)) ? true : false;
 }
 
 


### PR DESCRIPTION
In order to implement equivalence for templates wrapped in a ContextClosure in derby-templates, we need a way to implement a custom equality function. This will be used to prevent over-rendering in situations where two condition objects should be treated as equal even if they are different by reference