### PR TITLE
[DO NOT MERGE] Implement iterator template rendering & promise values for HTML rendering

### DIFF
--- a/example/expressions.js
+++ b/example/expressions.js
@@ -115,6 +115,12 @@ Context.prototype.flush = function() {
 Context.prototype.queue = function(cb) {
   this.meta.pending.push(cb);
 };
+Context.prototype.getIterator = function() {
+  return this.meta.iterator;
+};
+Context.prototype.setIterator = function(iterator) {
+  this.meta.iterator = iterator;
+};
 
 function noop() {}
 function ContextMeta() {
@@ -123,4 +129,5 @@ function ContextMeta() {
   this.removeNode = noop;
   this.pauseCount = 0;
   this.pending = [];
+  this.iterator = null;
 };

--- a/index.js
+++ b/index.js
@@ -98,6 +98,9 @@ exports.Block = Block;
 exports.ConditionalBlock = ConditionalBlock;
 exports.EachBlock = EachBlock;
 
+exports.Iterable = Iterable;
+exports.Iterator = Iterator;
+exports.Yield = Yield;
 exports.Attribute = Attribute;
 exports.DynamicAttribute = DynamicAttribute;
 
@@ -113,6 +116,20 @@ function Template(content, source) {
 }
 Template.prototype.toString = function() {
   return this.source;
+};
+Template.prototype.getHtmlIterable = function(context, unescaped) {
+  var template = this;
+  return new Iterable(function() {
+    return template.getHtmlIterator(context, unescaped);
+  });
+};
+Template.prototype.getHtmlIterator = function(context, unescaped) {
+  var template = this;
+  var iterator = new Iterator(function() {
+    return template.get(context, unescaped);
+  });
+  context.setIterator(iterator);
+  return iterator;
 };
 Template.prototype.get = function(context, unescaped) {
   return contentHtml(this.content, context, unescaped);
@@ -144,6 +161,98 @@ Template.prototype.module = 'templates';
 Template.prototype.type = 'Template';
 Template.prototype.serialize = function() {
   return serializeObject.instance(this, this.content, this.source);
+};
+
+function Iterable(createIterator) {
+  this[Symbol.iterator] = createIterator;
+}
+function Iterator(callback) {
+  this._accumulator = '';
+  this._stack = [];
+  this.queue(callback);
+}
+Iterator.prototype.next = function() {
+  if (this._stack.length === 0) {
+    return {value: undefined, done: true};
+  }
+  var stack = this._stack;
+  this._stack = [];
+  var value = reduceStack('', stack);
+  return {value: value, done: false};
+};
+Iterator.prototype.prepend = function(accumulator) {
+  this._accumulator = accumulator + this._accumulator;
+};
+Iterator.prototype.queue = function(callback) {
+  this._stack.push(callback);
+};
+Iterator.prototype.flush = function() {
+  var accumulator = this._accumulator;
+  this._accumulator = '';
+  return accumulator;
+};
+function reduceStack(accumulator, stack) {
+  var callback;
+  while (callback = stack.shift()) {
+    var value = callback(accumulator);
+    if (typeof value === 'string') {
+      accumulator = value;
+      continue;
+    }
+    callback = function(resolved) {
+      if (resolved instanceof Iterator) {
+        resolved.queue(callback);
+        return resolved.flush();
+      }
+      // Sanity check type
+      if (typeof resolved !== 'string') {
+        throw new Error('expected string to be produced from template iterator step');
+      }
+      var result = reduceStack(resolved, stack);
+      return (result instanceof Iterator) ? result.flush() : result;
+    };
+    if (value instanceof Iterator) {
+      value.queue(callback);
+      return value.flush();
+    } else {
+      return Promise.resolve(value).then(callback);
+    }
+  }
+  return accumulator;
+}
+function createDelayedValue(accumulator, value, callback) {
+  // Sanity check type
+  if (typeof accumulator !== 'string') {
+    throw new Error('accumulator argument must be a string');
+  }
+  if (value instanceof Iterator) {
+    value.prepend(accumulator);
+    value.queue(callback);
+    return value;
+  }
+  return Promise.resolve(value).then(function(resolved) {
+    if (resolved instanceof Iterator) {
+      resolved.prepend(accumulator);
+      resolved.queue(callback);
+      return resolved;
+    }
+    // Sanity check type
+    if (typeof resolved !== 'string') {
+      throw new Error('expected resolved promise to produce a string');
+    }
+    return callback(accumulator + resolved);
+  });
+}
+
+function Yield() {}
+Yield.prototype = Object.create(Template.prototype);
+Yield.prototype.constructor = Yield;
+Yield.prototype.type = 'Yield';
+Yield.prototype.get = function(context) {
+  return context.getIterator() || '';
+}
+Yield.prototype.serialize = function() {
+  return serializeObject.instance(this);
 };
 
 
@@ -591,7 +700,12 @@ Element.prototype.get = function(context) {
   var startTag = '<' + tagItems.join(' ') + this.startClose;
   if (this.content) {
     var inner = contentHtml(this.content, context, this.unescapedContent);
-    return startTag + inner + endTag;
+    if (typeof inner === 'string') {
+      return startTag + inner + endTag;
+    }
+    return createDelayedValue(startTag, inner, function(resolved) {
+      return resolved + endTag;
+    });
   }
   return startTag + endTag;
 };
@@ -1043,12 +1157,21 @@ function attachContent(parent, node, content, context) {
   }
   return node;
 }
-function contentHtml(content, context, unescaped) {
-  var html = '';
-  for (var i = 0, len = content.length; i < len; i++) {
-    html += content[i].get(context, unescaped);
+function appendHtmlFrom(accumulator, i, content, context, unescaped) {
+  for (var len = content.length; i < len; i++) {
+    var value = content[i].get(context, unescaped);
+    if (typeof value === 'string') {
+      accumulator += value;
+      continue;
+    }
+    return createDelayedValue(accumulator, value, function(resolved) {
+      return appendHtmlFrom(resolved, i + 1, content, context, unescaped);
+    });
   }
-  return html;
+  return accumulator;
+}
+function contentHtml(content, context, unescaped) {
+  return appendHtmlFrom('', 0, content, context, unescaped);
 }
 function replaceRange(context, start, end, fragment, binding, innerOnly) {
   // Note: the calling function must make sure to check that there is a parent

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "browserify": "^16.5.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "express": "^4.17.1",
     "mocha": "^6.2.2"
   },


### PR DESCRIPTION
Initial attempt at implementing delayed HTML rendering.

Consists of two new features:
1. Returning a promise value causes .get() rendering to return a promise. Thus, HTML rendering can support use of async values in addition to synchronous values with minimal additional overhead.
2. Implement iterator & iterable APIs that support the introduction of yield points in templates, inspired by JavaScript's `yield` keyword in generator functions

The combination of these features will make it possible to stream the HTML of a page in chunks generated by a single template representing the whole page. For example, it will be possible to do something like the following:

```html
<!DOCTYPE html>
<html>
<head>
<title>Test</title>
<script async src="scripts/bundle.js"></script>
{{yield}}
</head>
<body>
<header>
<h1>Test</h1>
</header>
{{yield}}
{{contentPromise}}
{{yield}}
<script type="application/json">{{dataBundlePromise}}</script>
</body>
</html>
```

The above example uses multiple yields in order to send the page in custom performance optimized chunks:
1. head with an async script tag to kick off a parallel load and execution of the external scripts
2. the top page chrome before any data is loaded
3. the main HTML content for the page
4. the data needed to bootstrap the page