### PR TITLE
Fix inputting of decimals like "1.01" in <input type="number">

### DIFF
--- a/test/test.mocha.js
+++ b/test/test.mocha.js
@@ -717,6 +717,25 @@ function testBindingUpdates(render) {
     expect(input.value).equal('');
   });
 
+  it('does not clobber input type="number" value when typing "1.0"', function() {
+    var template = new saddle.Template([
+      new saddle.Element('input', {
+        'type': new saddle.Attribute('number'),
+        'value': new saddle.DynamicAttribute(new expressions.Expression('amount')),
+      })
+    ]);
+
+    var binding = render(template).pop();
+    var input = fixture.firstChild;
+
+    // Make sure that a user-typed input value of "1.0" does not get clobbered by
+    // a context value of `1`.
+    input.value = '1.0';
+    binding.context = getContext({amount: 1});
+    binding.update();
+    expect(input.value).equal('1.0');
+  });
+
   it('updates "title" attribute', function() {
     var template = new saddle.Template([
       new saddle.Element('div', {


### PR DESCRIPTION
This PR fixes a bug in Derby where a user cannot enter decimals like "1.01" into an element like this:
```html
<input type="number" value="{{modelValue}}">
```

As soon as the user has typed, say, "1.0", the input immediately gets reset to "1". This applies to any decimal that starts with "NN.0".

## Explanation of the issue

For bindings in `<input type="number" value="{{modelValue}}">`, Derby will automatically turn the user-entered value into a numeric `modelValue`.

That's done in here:
https://github.com/derbyjs/derby/blob/57d28637e8489244cc8438041e6c61d9468cd344/lib/documentListeners.js#L23-L25
https://github.com/derbyjs/derby/blob/57d28637e8489244cc8438041e6c61d9468cd344/lib/documentListeners.js#L99-L102

However, the `expression.set(binding.context, value)` in the second link eventually results in `DynamicAttribute.update` getting called.

That function does do a check to skip updating the property if it doesn't need to be changed. However, because the HTML input `value` property is a string, the code stringifies `1` into `'1'`, then compares it to the user-entered value `'1.0'`. The two are different, so the code sets the value to `'1'`, resulting in the observed bug.

## The fix

Special-case updates to the `<input type="number">` value property to do a comparison based on the numeric value.