### PR TITLE
Update package main field to correct path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/derbyjs/saddle.git"
   },
   "version": "0.9.7",
-  "main": "./lib/index.js",
+  "main": "./index.js",
   "scripts": {
     "test": "mocha test/serialize.mocha.js --bail --colors --reporter spec; node test/testServer.js"
   },


### PR DESCRIPTION
Fix warnings at build time for `main` field that points to invalid file path